### PR TITLE
Serve bootstrap app from worker

### DIFF
--- a/packages/gateway-client/src/app/components/home/home.tsx
+++ b/packages/gateway-client/src/app/components/home/home.tsx
@@ -139,8 +139,9 @@ export function Home(_props: HomeProps) {
         window.navigator.serviceWorker.controller?.postMessage({
             type: ClientMessageType.OPENED,
         });
+
         // we've accomplished all we needed, time to go
-        window.location.href = '/';
+        window.location.href = '/timeline/fediverse';
     }, [pwaOpen, secureContext, workerActive]);
 
     return (

--- a/packages/gateway-client/src/app/components/home/home.tsx
+++ b/packages/gateway-client/src/app/components/home/home.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
+import { ClientMessageType } from '../../../service-worker';
 import { selectWorkerStatus } from '../../redux/service-worker/serviceWorker.slice';
 import {
     getSupportedPlatform,
@@ -126,7 +127,7 @@ export function Home(_props: HomeProps) {
 
         // let the worker know we're up and running
         window.navigator.serviceWorker.controller?.postMessage({
-            type: 'START',
+            type: ClientMessageType.OPENED,
         });
         // we've accomplished all we needed, time to go
         window.location.href = '/';

--- a/packages/gateway-client/src/app/components/home/home.tsx
+++ b/packages/gateway-client/src/app/components/home/home.tsx
@@ -95,7 +95,17 @@ export function Home(_props: HomeProps) {
         if (!secureContext) {
             // then there is no point in even trying
             setStatusMessage(
-                'Missing secure context. (Is insecure origin flag set?)'
+                <>
+                    Missing secure context. (Is the{' '}
+                    <a
+                        href="https://samizdapp.github.io/docs/getting-started/setup-client"
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        insecure origin flag
+                    </a>{' '}
+                    set?)
+                </>
             );
             return;
         } // else, we have a secure context

--- a/packages/gateway-client/src/app/redux/service-worker/serviceWorker.logic.ts
+++ b/packages/gateway-client/src/app/redux/service-worker/serviceWorker.logic.ts
@@ -77,6 +77,8 @@ export class ServiceWorkerLogic {
             resolve => {
                 register({
                     onSuccess: resolve,
+                    onUpdate: resolve,
+                    onExisting: resolve,
                 });
             }
         );

--- a/packages/gateway-client/src/service-worker.ts
+++ b/packages/gateway-client/src/service-worker.ts
@@ -4,11 +4,16 @@ export enum ServerPeerStatus {
     CONNECTED = 'CONNECTED',
 }
 
-export enum MessageType {
+export enum WorkerMessageType {
     SERVER_PEER_STATUS = 'SERVER_PEER_STATUS',
     LOADED_RELAYS = 'LOADED_RELAYS',
 }
 
-export type Message = {
-    type: MessageType;
+export enum ClientMessageType {
+    REQUEST_STATUS = 'REQUEST_STATUS',
+    OPENED = 'OPENED',
+}
+
+export type Message<T extends WorkerMessageType | ClientMessageType> = {
+    type: T;
 } & Record<string, unknown>;

--- a/packages/gateway-client/src/worker/index.ts
+++ b/packages/gateway-client/src/worker/index.ts
@@ -314,7 +314,7 @@ function patchFetchArgs(_reqObj: Request, _reqInit: RequestInit = {}) {
 
     const rawHeaders = Object.fromEntries(_reqObj.headers.entries());
 
-    if (url.pathname !== '/manifest.json' && !url.pathname.startsWith('/pwa')) {
+    if (url.pathname !== '/manifest.json') {
         rawHeaders['X-Intercepted-Subdomain'] = 'pleroma';
     }
 

--- a/packages/gateway-client/src/worker/index.ts
+++ b/packages/gateway-client/src/worker/index.ts
@@ -226,6 +226,12 @@ async function p2Fetch(
             `Patched service worker \`fetch()\` method expects a full request object, received ${reqObj.constructor.name}`
         );
     }
+    if (
+        process.env.NX_LOCAL === 'true' &&
+        new URL(reqObj.url).pathname.startsWith('/pwa')
+    ) {
+        return self.stashedFetch(reqObj, reqInit);
+    }
     const patched = patchFetchArgs(reqObj, reqInit);
     const body = reqObj.body
         ? reqObj.body

--- a/packages/gateway-client/src/worker/index.ts
+++ b/packages/gateway-client/src/worker/index.ts
@@ -314,7 +314,7 @@ function patchFetchArgs(_reqObj: Request, _reqInit: RequestInit = {}) {
 
     const rawHeaders = Object.fromEntries(_reqObj.headers.entries());
 
-    if (url.pathname !== '/manifest.json') {
+    if (url.pathname !== '/manifest.json' && !url.pathname.startsWith('/pwa')) {
         rawHeaders['X-Intercepted-Subdomain'] = 'pleroma';
     }
 

--- a/packages/shared/service-worker/src/lib/registration.ts
+++ b/packages/shared/service-worker/src/lib/registration.ts
@@ -28,6 +28,7 @@ const isLocalhost = Boolean(
 type Config = {
     onSuccess?: (registration: ServiceWorkerRegistration) => void;
     onUpdate?: (registration: ServiceWorkerRegistration) => void;
+    onExisting?: (registration: ServiceWorkerRegistration) => void;
 };
 
 export function register(config?: Config) {
@@ -67,6 +68,15 @@ function registerValidSW(swUrl: string, config?: Config) {
             scope: '/',
         })
         .then(registration => {
+            // if this worker is already active and in control
+            if (
+                registration.active &&
+                registration.active ===
+                    window.navigator.serviceWorker.controller
+            ) {
+                // then resolve with our existing worker
+                config?.onExisting?.(registration);
+            }
             registration.onupdatefound = () => {
                 const installingWorker = registration.installing;
                 if (installingWorker == null) {


### PR DESCRIPTION
- Bypasses proxy for serving `/pwa` when running locally. 
- Fixes bugs in the bootstrapper app around getting status of existing worker
- Requested updates to bootstrapper logic