### PR TITLE
#19 SAM-18 Reduce size of gateway-client image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:18-alpine as build
+
+RUN apk add python3 make gcc g++
+
+RUN mkdir -p /usr/src/athena
+
+WORKDIR /usr/src/athena
+
+COPY package.json .
+COPY package-lock.json .
+
+RUN npm install

--- a/packages/gateway-client/Dockerfile
+++ b/packages/gateway-client/Dockerfile
@@ -1,16 +1,8 @@
-FROM node:18-alpine as build
+FROM herakles_athena:latest as build
 
-RUN apk add python3 make gcc g++
-
-RUN mkdir -p /usr/src/athena
 RUN mkdir -p /usr/src/volumes/gateway_client
 
 WORKDIR /usr/src/athena
-
-COPY package.json .
-COPY package-lock.json .
-
-RUN npm install
 
 COPY . .
 
@@ -24,5 +16,6 @@ RUN apk add --no-cache bash
 WORKDIR /usr/src/athena
 
 COPY --from=build /usr/src/athena/dist .
+COPY ./packages/gateway-client/copy.sh ./gateway-client-copy.sh
 
-CMD [ "/bin/bash", "./packages/gateway-client/copy.sh"  ]
+CMD [ "/bin/bash", "./gateway-client-copy.sh"  ]

--- a/packages/gateway-client/Dockerfile
+++ b/packages/gateway-client/Dockerfile
@@ -1,6 +1,5 @@
-FROM node:18-alpine
+FROM node:18-alpine as build
 
-RUN apk add --no-cache bash
 RUN apk add python3 make gcc g++
 
 RUN mkdir -p /usr/src/athena
@@ -16,5 +15,14 @@ RUN npm install
 COPY . .
 
 RUN npm run build gateway-client
+
+
+FROM node:18-alpine as run
+
+RUN apk add --no-cache bash
+
+WORKDIR /usr/src/athena
+
+COPY --from=build /usr/src/athena/dist .
 
 CMD [ "/bin/bash", "./packages/gateway-client/copy.sh"  ]


### PR DESCRIPTION
Fixes https://github.com/samizdapp/herakles/issues/19

Implements a base athena docker image for running npm install, and uses a multi-stage build in the gateway-client Dockerfile to reduce image size.