### PR TITLE
SAM-40 move /smz to /smz/pwa

### DIFF
--- a/packages/gateway-client/project.json
+++ b/packages/gateway-client/project.json
@@ -11,7 +11,7 @@
         "compiler": "babel",
         "outputPath": "dist/packages/gateway-client",
         "index": "packages/gateway-client/src/index.html",
-        "baseHref": "/smz/",
+        "baseHref": "/smz/pwa/",
         "main": "packages/gateway-client/src/main.tsx",
         "polyfills": "packages/gateway-client/src/polyfills.ts",
         "tsConfig": "packages/gateway-client/tsconfig.app.json",

--- a/packages/gateway-client/src/app/app.tsx
+++ b/packages/gateway-client/src/app/app.tsx
@@ -14,9 +14,9 @@ export function App() {
     return (
         <StyledApp>
             <Routes>
-                <Route path="/smz" element={<Home />} />
-                <Route path="/smz/status" element={<Status />} />
-                <Route path="*" element={<Navigate to="/smz" replace />} />
+                <Route path="/smz/pwa" element={<Home />} />
+                <Route path="/smz/pwa/status" element={<Status />} />
+                <Route path="*" element={<Navigate to="/smz/pwa" replace />} />
             </Routes>
         </StyledApp>
     );

--- a/packages/gateway-client/src/app/components/home/status.tsx
+++ b/packages/gateway-client/src/app/components/home/status.tsx
@@ -265,7 +265,7 @@ export function Status() {
                     </pre>
                 </div>
 
-                <Link className="service-status-link" to="/smz/status">
+                <Link className="service-status-link" to="/smz/pwa/status">
                     SamizdApp Status
                 </Link>
             </div>

--- a/packages/gateway-client/src/manifest.json
+++ b/packages/gateway-client/src/manifest.json
@@ -2,7 +2,7 @@
   "short_name": "SamizdApp",
   "name": "SamizdApp",
   "scope": "/",
-  "start_url": "/smz",
+  "start_url": "/smz/pwa",
   "icons": [
     {
       "src": "favicon.ico",

--- a/packages/gateway-client/src/worker/index.ts
+++ b/packages/gateway-client/src/worker/index.ts
@@ -347,12 +347,13 @@ class WorkerStatus {
 }
 self.status = new WorkerStatus();
 
+const isBootstrapAppUrl = (url: URL): boolean =>
+    url.pathname.startsWith('/smz/pwa');
+
 const getClient = async (): Promise<WindowClient | undefined> => {
     const allClients = await self.clients.matchAll();
     return allClients.find(
-        it =>
-            it instanceof WindowClient &&
-            new URL(it.url).pathname.startsWith('/smz')
+        it => it instanceof WindowClient && isBootstrapAppUrl(new URL(it.url))
     ) as WindowClient;
 };
 
@@ -431,7 +432,7 @@ async function p2Fetch(
             : `http://localhost${reqObj.url}`
     );
 
-    if (process.env.NX_LOCAL === 'true' && url.pathname.startsWith('/smz')) {
+    if (process.env.NX_LOCAL === 'true' && isBootstrapAppUrl(url)) {
         return self.stashedFetch(givenReqObj, givenReqInit);
     }
 
@@ -609,7 +610,7 @@ function getHostAddrs(hostname: string, tail: string[]): string[] {
 async function getBootstrapList() {
     let newBootstrapAddress = null;
     try {
-        newBootstrapAddress = await fetch('/smz/assets/libp2p.bootstrap')
+        newBootstrapAddress = await fetch('/smz/pwa/assets/libp2p.bootstrap')
             .then(res => {
                 if (res.status >= 400) {
                     throw res;

--- a/packages/gateway-client/src/worker/index.ts
+++ b/packages/gateway-client/src/worker/index.ts
@@ -623,7 +623,7 @@ async function getBootstrapList() {
     }
     const cachedBootstrapAddress =
         (await localforage.getItem<string>('libp2p.bootstrap')) ?? null;
-    const bootstrapaddr = newBootstrapAddress ?? cachedBootstrapAddress;
+    const bootstrapaddr = newBootstrapAddress || cachedBootstrapAddress;
     if (bootstrapaddr !== cachedBootstrapAddress) {
         console.debug(
             'Detected updated bootstrap address, updating cache: ',


### PR DESCRIPTION
One or two references to `/smz` remain in place as they reference the namespace, not the bootstrap app.