### PR TITLE
SAM-79 prefer server id from bootstrap

### DIFF
--- a/packages/gateway-client/src/worker/p2p-client/index.ts
+++ b/packages/gateway-client/src/worker/p2p-client/index.ts
@@ -300,7 +300,7 @@ export class P2pClient {
 
         // update status
         this.connectionStatus = ServerPeerStatus.CONNECTING;
-        waitFor(15000).then(() => {
+        waitFor(30000).then(() => {
             if (this.connectionStatus === ServerPeerStatus.CONNECTING) {
                 this.connectionStatus = ServerPeerStatus.OFFLINE;
             }

--- a/packages/gateway-client/src/worker/p2p-client/index.ts
+++ b/packages/gateway-client/src/worker/p2p-client/index.ts
@@ -96,7 +96,7 @@ export class P2pClient {
             // - and is less than a minute old
             if (
                 connection?.stat?.status === 'OPEN' &&
-                connection.stat?.timeline.open < Date.now() - 60 * 1000
+                connection.stat?.timeline.open > Date.now() - 60 * 1000
             ) {
                 // this is a newly opened connection
                 // instead of creating a second one


### PR DESCRIPTION
- Override the `BootstrapList.serverId` with the id from the fetched bootstrap address
- Reduce connection time by reducing initial stats population timeout (repopulate later with longer timeout)
- Bug fix: old connections were still being returned on stream timeout
- Status now goes to `OFFLINE` after 30 seconds (was previously 15)