### PR TITLE
Refactor p2p client reconnect logic

### DIFF
--- a/packages/gateway-client/src/worker/fetch-handlers/pleroma-timeline-handler.spec.ts
+++ b/packages/gateway-client/src/worker/fetch-handlers/pleroma-timeline-handler.spec.ts
@@ -26,7 +26,6 @@ describe('pleromaTimelineHandler() should', () => {
         };
         const respondWith = jest.fn();
         pleromaTimelineHandler(request as Request, respondWith);
-        expect(respondWith).toHaveBeenCalledWith(fetch(request as Request));
         await getWindowClient(() => true);
         expect(mockClient.navigate).toHaveBeenCalledWith('/timeline/fediverse');
     });

--- a/packages/gateway-client/src/worker/fetch-handlers/pleroma-timeline-handler.ts
+++ b/packages/gateway-client/src/worker/fetch-handlers/pleroma-timeline-handler.ts
@@ -1,7 +1,7 @@
 import { getWindowClient } from '../client';
 import { Handler } from './fetch-handlers';
 
-export const pleromaTimelineHandler: Handler = (request, respondWith) => {
+export const pleromaTimelineHandler: Handler = request => {
     // handle requests to the pleroma timeline
     const { pathname, searchParams } = new URL(request.url);
     if (pathname === '/api/v1/timelines/public' && searchParams.get('local')) {
@@ -14,8 +14,7 @@ export const pleromaTimelineHandler: Handler = (request, respondWith) => {
         });
     }
 
-    // always pass the request to fetch regardless
-    respondWith(fetch(request));
+    // always allow request to continue regardless
 };
 
 export default pleromaTimelineHandler;

--- a/packages/gateway-client/src/worker/p2p-client/index.ts
+++ b/packages/gateway-client/src/worker/p2p-client/index.ts
@@ -1,22 +1,23 @@
 import { Noise } from '@chainsafe/libp2p-noise';
 import { ConnectionEncrypter } from '@libp2p/interface-connection-encrypter';
-import { Connection } from '@libp2p/interface-connection';
 import { PeerId } from '@libp2p/interface-peer-id';
 import type { Address } from '@libp2p/interface-peer-store';
 import { KEEP_ALIVE } from '@libp2p/interface-peer-store/tags';
 import { StreamMuxerFactory } from '@libp2p/interface-stream-muxer';
+import { Startable } from '@libp2p/interfaces/startable';
 import { Mplex } from '@libp2p/mplex';
 import { WebSockets } from '@libp2p/websockets';
 import { all as filtersAll } from '@libp2p/websockets/filters';
 import { Multiaddr as MultiaddrType } from '@multiformats/multiaddr';
 import { createLibp2p, Libp2p } from 'libp2p';
+import { Libp2pNode } from 'libp2p/libp2p';
 
 import { ServerPeerStatus } from '../../worker-messaging';
 import { logger } from '../logging';
 import status from '../status';
 import { BootstrapList } from './bootstrap-list';
 import { initLibp2pLogging } from './libp2p-logging';
-import { StreamFactory, RequestStream } from './stream-factory';
+import { RequestStream, StreamFactory } from './stream-factory';
 
 const waitFor = async (t: number): Promise<void> =>
     new Promise(r => setTimeout(r, t));
@@ -31,7 +32,6 @@ export class P2pClient {
     private eventTarget = new EventTarget();
 
     private serverPeer?: PeerId;
-    private serverConnection?: Promise<Connection>;
     public node?: Libp2p;
     private _connectionStatus: ServerPeerStatus = ServerPeerStatus.OFFLINE;
 
@@ -66,7 +66,36 @@ export class P2pClient {
         return this.streamFactory.getStream(protocol);
     }
 
-    public async connectToServer(retryTimeout = 1000): Promise<Connection> {
+    public async performDialAction<T>(
+        action: (signal: AbortSignal) => Promise<T>,
+        timeout = this.DIAL_TIMEOUT
+    ) {
+        const abortController = new AbortController();
+        const signal = abortController.signal;
+        waitFor(timeout).then(() => abortController.abort());
+        return Promise.race([
+            action(signal),
+            waitFor(timeout + 1000).then(() => {
+                throw new Error(
+                    'Abort controller failed to abort within 1 second past timeout.'
+                );
+            }),
+        ]);
+    }
+
+    private setDisconnectedStatus() {
+        // if our status has already been set
+        if (this.connectionStatus !== ServerPeerStatus.CONNECTED) {
+            // then we don't need to set it again
+            return;
+        }
+
+        // update status
+        this.connectionStatus = ServerPeerStatus.CONNECTING;
+        this.dispatchEvent('disconnected');
+    }
+
+    private async connectToServer(retryTimeout = 1000): Promise<void> {
         // if we haven't started yet
         if (!this.node) {
             throw new Error(
@@ -81,34 +110,8 @@ export class P2pClient {
             );
         }
 
-        // if we already have a connection (completed or pending)
-        if (this.serverConnection) {
-            // get the connection so we can take a closer look at it
-            let connection;
-            try {
-                connection = await this.serverConnection;
-            } catch (e) {
-                // ignore errors
-            }
-            // if this connection:
-            // - exists
-            // - is open
-            // - and is less than a minute old
-            if (
-                connection?.stat?.status === 'OPEN' &&
-                connection.stat?.timeline.open > Date.now() - 60 * 1000
-            ) {
-                // this is a newly opened connection
-                // instead of creating a second one
-                // just return the connection we just made
-                return this.serverConnection;
-            }
-            // else, this connection may have failed, be closed,
-            // or be old (could have failed more exotically)
-            // we should discard it and create a new connection
-        }
-
         // first, close any open connections to our server
+        this.setDisconnectedStatus();
         this.log.debug('Closing existing server connections...');
         await this.node.hangUp(this.serverPeer);
 
@@ -123,26 +126,86 @@ export class P2pClient {
 
         // now, attempt to dial our server
         this.log.info('Dialing server...');
-        this.serverConnection = this.node
-            .dial(this.serverPeer)
-            .catch(async e => {
-                // we weren't able to dial
-                this.log.error('Error dialing server: ', e);
-                this.log.debug('Retrying dial in: ', retryTimeout);
-                this.serverConnection = undefined;
-                // wait before retrying
-                await waitFor(retryTimeout);
-                // refresh our stats so that the dial gets an updated order
-                await this.bootstrapList.refreshStats();
-                // retry
-                this.log.info('Redialing server...');
-                return this.connectToServer(
-                    retryTimeout > 30000 ? retryTimeout : retryTimeout + 1000
-                );
-            });
+        try {
+            const connection = await this.performDialAction(
+                signal =>
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    this.node!.dial(this.serverPeer!, {
+                        signal,
+                    }),
+                retryTimeout * 2
+            );
+            this.log.debug(
+                'Successfully dialed: ',
+                connection.remoteAddr.toString()
+            );
+        } catch (e) {
+            // we weren't able to dial
+            this.log.error('Error dialing server: ', e);
+            this.log.debug('Retrying dial in: ', retryTimeout);
+            // wait before retrying
+            await waitFor(retryTimeout);
+            // refresh our stats so that the dial gets an updated order
+            await this.bootstrapList.refreshStats();
+            // retry
+            this.log.info('Redialing server...');
+            return this.connectToServer(
+                retryTimeout > 30000 ? 1000 : retryTimeout + 1000
+            );
+        }
+    }
 
-        // return our connection
-        return this.serverConnection;
+    private async loopConnectionStatus(failedAttempts = 0) {
+        const loopInterval = 5000;
+        // keep our connection status in sync
+        if (
+            (!this.node || !this.serverPeer) &&
+            this.connectionStatus === ServerPeerStatus.CONNECTED
+        ) {
+            this.connectionStatus = ServerPeerStatus.CONNECTING;
+        }
+        // if we're not connected
+        if (this.connectionStatus !== ServerPeerStatus.CONNECTED) {
+            // then there is nothing to loop
+            this.log.trace(
+                'Skipping connection status loop. Status: ',
+                this.connectionStatus
+            );
+            await waitFor(loopInterval);
+            this.loopConnectionStatus();
+            return;
+        }
+
+        // else, we want to make sure our connection is still good
+        // if we've had failed attempts, then wait a bit
+        await waitFor(failedAttempts * 1000);
+        try {
+            // now, ping our server
+            this.log.trace('Pinging server: ', this.serverPeer?.toString());
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            await this.node!.ping(this.serverPeer!);
+            // if our ping was successful, then our connection is still good
+            this.log.trace('Ping successful!');
+        } catch (e) {
+            // if we haven't failed two times yet
+            if (++failedAttempts < 2) {
+                // then try again
+                this.log.debug(
+                    `Ping failed, retrying (failed attempts: ${failedAttempts})`
+                );
+                this.loopConnectionStatus(failedAttempts);
+                return;
+            }
+            // else, we've tried enough, we've lost our connection
+            this.log.warn('Server connection lost (error pinging server): ', e);
+            this.setDisconnectedStatus();
+            // try to reconnect
+            this.connectToServer();
+        }
+
+        // we've reached the end our our loop
+        await waitFor(loopInterval);
+        this.loopConnectionStatus();
     }
 
     public async start() {
@@ -211,8 +274,11 @@ export class P2pClient {
                 // if this is our server peer
                 if (this.bootstrapList.serverId === peerId) {
                     this.serverPeer = evt.detail.id;
-                    // connect to our server (autodial is disabled)
-                    this.connectToServer();
+                    // if we're not connected
+                    if (this.connectionStatus !== ServerPeerStatus.CONNECTED) {
+                        // connect to our server (autodial is disabled)
+                        this.connectToServer();
+                    }
                 }
             }
         });
@@ -243,20 +309,23 @@ export class P2pClient {
                     }
 
                     // else, we've connected to our server
-                    this.log.info('Connected to server.');
+                    this.log.info('Gained connection to server.');
 
-                    if (!this.serverConnection) {
-                        this.serverConnection = Promise.resolve(connection);
+                    // if we were already connected
+                    if (this.connectionStatus === ServerPeerStatus.CONNECTED) {
+                        // then there is no more to do
+                        return;
                     }
+
+                    // update status
+                    this.connectionStatus = ServerPeerStatus.CONNECTED;
+
                     this.streamFactory = new StreamFactory(
                         this.DIAL_TIMEOUT,
                         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                         this.serverPeer!,
                         this
                     );
-
-                    // update status
-                    this.connectionStatus = ServerPeerStatus.CONNECTED;
 
                     // set keep-alive on connection
                     try {
@@ -277,19 +346,15 @@ export class P2pClient {
         // Listen for peers disconnecting
         this.node.connectionManager.addEventListener('peer:disconnect', evt => {
             const connection = evt.detail;
-            this.log.info(
-                `Disconnected from ${connection.remotePeer.toString()}`
-            );
+            this.log.info('Disconnected from: ', {
+                server: connection.remotePeer.toString(),
+                via: connection.remoteAddr.toString(),
+            });
             if (
-                this.serverPeer &&
-                connection.remotePeer.equals(this.serverPeer)
+                this.connectionStatus === ServerPeerStatus.CONNECTED &&
+                connection.remotePeer.equals(this.serverPeer ?? '')
             ) {
-                this.log.warn('Disconnected from server.');
-                this.serverConnection = undefined;
-                // update status
-                this.connectionStatus = ServerPeerStatus.CONNECTING;
-                this.dispatchEvent('disconnected');
-                this.connectToServer();
+                this.log.warn('Lost connection from server.');
             }
         });
 
@@ -297,6 +362,8 @@ export class P2pClient {
         this.log.debug('Starting libp2p...');
         await this.node.start();
         this.log.info('Started libp2p.');
+        // start our connection status loop
+        this.loopConnectionStatus();
 
         // update status
         this.connectionStatus = ServerPeerStatus.CONNECTING;

--- a/packages/gateway-client/src/worker/p2p-client/stream-factory.ts
+++ b/packages/gateway-client/src/worker/p2p-client/stream-factory.ts
@@ -171,7 +171,12 @@ export class StreamFactory {
                     this.dialTimeout
                 )
                 .catch(e => {
-                    this.log.trace('dialProtocol error: ', e);
+                    const log = ['dialProtocol error: ', e];
+                    if (['ERR_UNSUPPORTED_PROTOCOL'].includes(e.code)) {
+                        this.log.error(...log);
+                    } else {
+                        this.log.debug(...log);
+                    }
                     this.log.trace('Time: ', Date.now() - start);
                     return null;
                 });

--- a/packages/gateway-client/src/worker/p2p-client/stream-factory.ts
+++ b/packages/gateway-client/src/worker/p2p-client/stream-factory.ts
@@ -221,12 +221,12 @@ export class StreamFactory {
                 status.serverPeer = ServerPeerStatus.CONNECTING;
             }
 
-            // if our retry timeout reaches 5 seconds, then we'll have
-            // been retrying for 15 seconds (triangle number of 5).
+            // if our retry timeout reaches 7 seconds, then we'll have
+            // been retrying for 28 seconds (triangle number of 7).
             // By this point, we're probably offline.
             if (
                 status.serverPeer !== ServerPeerStatus.OFFLINE &&
-                this.retryTimeout >= 5000
+                this.retryTimeout >= 7000
             ) {
                 status.serverPeer = ServerPeerStatus.OFFLINE;
             }

--- a/packages/gateway-client/src/worker/p2p-client/stream-factory.ts
+++ b/packages/gateway-client/src/worker/p2p-client/stream-factory.ts
@@ -157,13 +157,19 @@ export class StreamFactory {
 
             // attempt to dial our peer, track the time it takes
             const start = Date.now();
-            // timeout after configured timeout
-            const abortController = new AbortController();
-            const signal = abortController.signal;
-            waitFor(this.dialTimeout).then(() => abortController.abort());
-            // initiate dial
-            stream = await this.client.node
-                .dialProtocol(this.serverPeer, protocol, { signal })
+            stream = await this.client
+                .performDialAction(
+                    signal =>
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                        this.client.node!.dialProtocol(
+                            this.serverPeer,
+                            protocol,
+                            {
+                                signal,
+                            }
+                        ),
+                    this.dialTimeout
+                )
                 .catch(e => {
                     this.log.trace('dialProtocol error: ', e);
                     this.log.trace('Time: ', Date.now() - start);
@@ -221,7 +227,7 @@ export class StreamFactory {
             }
 
             // wait awhile before retrying the stream again
-            this.log.info('Dial timeout, waiting to reset...', {
+            this.log.info('Dial timeout, waiting to retry...', {
                 dialTimeout: this.dialTimeout,
                 retryTimeout: this.retryTimeout,
             });
@@ -240,9 +246,7 @@ export class StreamFactory {
             // 5 minutes
             this.dialTimeout = Math.min(1000 * 60 * 5, this.dialTimeout * 4);
 
-            // now that we've waited awhile, we can attempt to reconnect to our server
-            await this.client.connectToServer();
-            // and try again
+            // now that we've waited awhile, we can try again
             this.inTimeout = false;
         }
 


### PR DESCRIPTION
# Problems this solves

- When many valid bootstrap addresses exist, libp2p will connect to many of them, and we'll have many connections to our box
  - This causes a lot of issues with the current connect/reconnect logic that stores a connection in state
  - Connect/disconnect loops were more likely to happen the more valid addresses were in the list
- Some dial attempts would hang and not respond to abort attempts
  - This could result in the client being unable to recover from losing internet access

# The solution

- Track the state of the connection via `connectionStatus` property only
- Implement a loop that periodically pings the box in order to keep the connection status up-to-date
- Only mark the client as disconnected or attempt to reconnect when the ping fails
  - We no longer set any connection state from the disconnect handler
- Anything else that needs to use the connection simply needs to keep retrying or wait until the connection becomes available again

# Observed issues

If I block traffic to all working addresses, wait for the client to being retrying, then unblock only my LAN, the client will get into a connect/disconnect loop where libp2p fires a disconnect moments after the connect is fired for the same remote address (my LAN address). During this time, any attempts to dial will fail, and the connect/disconnect loop is not resolved by reconnecting. It isn't clear what could be causing this, as I don't see anything on our side that could be causing the disconnect.

When this happens, allowing traffic via another address will resolve the issue. After again blocking traffic via the new address, LAN will continue working. This only happens if the first address to be unblocked is my LAN (other addresses being unblocked first with LAN being unblocked 2nd don't display this issue). It could be a glitch either in my box or with my network.

It isn't possible to attempt to reproduce this on `develop` as the bug that prevents a client from regaining lost internet access would mask this behavior.