### PR TITLE
SAM-93 limit bootstrap list

### DIFF
--- a/packages/gateway-client/src/worker/p2p-client/index.ts
+++ b/packages/gateway-client/src/worker/p2p-client/index.ts
@@ -133,7 +133,7 @@ export class P2pClient {
         this.log.debug('Re-adding server peer addresses');
         this.node.peerStore.addressBook.add(
             this.serverPeer,
-            this.bootstrapList.all().map(it => it.multiaddr)
+            this.bootstrapList.multiaddrList
         );
 
         // now, attempt to dial our server

--- a/packages/gateway-client/src/worker/p2p-client/index.ts
+++ b/packages/gateway-client/src/worker/p2p-client/index.ts
@@ -29,6 +29,7 @@ export class P2pClient {
 
     private DIAL_TIMEOUT = 3000;
     private MAX_PARALLEL_DIALS = 20;
+    private MAX_DIALS_PER_PEER = 20;
 
     private streamFactory?: StreamFactory;
     private bootstrapList: BootstrapList;
@@ -40,7 +41,7 @@ export class P2pClient {
     private _connectionStatus: ServerPeerStatus = ServerPeerStatus.OFFLINE;
 
     public constructor() {
-        this.bootstrapList = new BootstrapList(this);
+        this.bootstrapList = new BootstrapList(this, this.MAX_DIALS_PER_PEER);
     }
 
     public get connectionStatus(): ServerPeerStatus {
@@ -247,7 +248,7 @@ export class P2pClient {
                 // explicitly disabled (removed in later version)
                 autoDial: false,
                 minConnections: 3,
-                maxDialsPerPeer: 20,
+                maxDialsPerPeer: this.MAX_DIALS_PER_PEER,
                 maxParallelDials: this.MAX_PARALLEL_DIALS,
                 addressSorter: (a: Address, b: Address) =>
                     this.bootstrapList.libp2pAddressSorter(a, b),


### PR DESCRIPTION
In the event that more addresses are stored than libp2p will allow, we'll only pass the top address to libp2p to avoid an error.