### PR TITLE
Jc/ops/restructure lint athena libp2p module

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,201 @@
           {
             "checkLoops": false
           }
+        ],
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "@chainsafe/libp2p-noise",
+                "message": "Please use @athena/shared/libp2p/@chainsafe/libp2p-noise instead."
+              },
+              {
+                "name": "@libp2p/mplex",
+                "message": "Please use @athena/shared/libp2p/@libp2p/mplex instead."
+              },
+              {
+                "name": "@libp2p/peer-id-factory",
+                "message": "Please use @athena/shared/libp2p/@libp2p/peer-id-factory instead."
+              },
+              {
+                "name": "@libp2p/websockets",
+                "message": "Please use @athena/shared/libp2p/@libp2p/websockets instead."
+              },
+              {
+                "name": "@multiformats/multiaddr",
+                "message": "Please use @athena/shared/libp2p/@multiformats/multiaddr instead."
+              },
+              {
+                "name": "internal-ip",
+                "message": "Please use @athena/shared/libp2p/internal-ip instead."
+              },
+              {
+                "name": "libp2p",
+                "message": "Please use @athena/shared/libp2p/libp2p instead."
+              },
+              {
+                "name": "assert",
+                "message": "Please use node:assert instead."
+              },
+              {
+                "name": "buffer",
+                "message": "Please use node:buffer instead."
+              },
+              {
+                "name": "child_process",
+                "message": "Please use node:child_process instead."
+              },
+              {
+                "name": "cluster",
+                "message": "Please use node:cluster instead."
+              },
+              {
+                "name": "console",
+                "message": "Please use node:console instead."
+              },
+              {
+                "name": "constants",
+                "message": "Please use node:constants instead."
+              },
+              {
+                "name": "crypto",
+                "message": "Please use node:crypto instead."
+              },
+              {
+                "name": "dgram",
+                "message": "Please use node:dgram instead."
+              },
+              {
+                "name": "dns",
+                "message": "Please use node:dns instead."
+              },
+              {
+                "name": "domain",
+                "message": "Please use node:domain instead."
+              },
+              {
+                "name": "events",
+                "message": "Please use node:events instead."
+              },
+              {
+                "name": "fs",
+                "message": "Please use node:fs instead."
+              },
+              {
+                "name": "fs/promises",
+                "message": "Please use node:fs/promises instead."
+              },
+              {
+                "name": "http",
+                "message": "Please use node:http instead."
+              },
+              {
+                "name": "https",
+                "message": "Please use node:https instead."
+              },
+              {
+                "name": "inspector",
+                "message": "Please use node:inspector instead."
+              },
+              {
+                "name": "module",
+                "message": "Please use node:module instead."
+              },
+              {
+                "name": "net",
+                "message": "Please use node:net instead."
+              },
+              {
+                "name": "os",
+                "message": "Please use node:os instead."
+              },
+              {
+                "name": "path",
+                "message": "Please use node:path instead."
+              },
+              {
+                "name": "perf_hooks",
+                "message": "Please use node:perf_hooks instead."
+              },
+              {
+                "name": "process",
+                "message": "Please use node:process instead."
+              },
+              {
+                "name": "punycode",
+                "message": "Please use node:punycode instead."
+              },
+              {
+                "name": "querystring",
+                "message": "Please use node:querystring instead."
+              },
+              {
+                "name": "readline",
+                "message": "Please use node:readline instead."
+              },
+              {
+                "name": "repl",
+                "message": "Please use node:repl instead."
+              },
+              {
+                "name": "stream",
+                "message": "Please use node:stream instead."
+              },
+              {
+                "name": "string_decoder",
+                "message": "Please use node:string_decoder instead."
+              },
+              {
+                "name": "sys",
+                "message": "Please use node:sys instead."
+              },
+              {
+                "name": "timers",
+                "message": "Please use node:timers instead."
+              },
+              {
+                "name": "tls",
+                "message": "Please use node:tls instead."
+              },
+              {
+                "name": "trace_events",
+                "message": "Please use node:trace_events instead."
+              },
+              {
+                "name": "tty",
+                "message": "Please use node:tty instead."
+              },
+              {
+                "name": "url",
+                "message": "Please use node:url instead."
+              },
+              {
+                "name": "util",
+                "message": "Please use node:util instead."
+              },
+              {
+                "name": "v8",
+                "message": "Please use node:v8 instead."
+              },
+              {
+                "name": "vm",
+                "message": "Please use node:vm instead."
+              },
+              {
+                "name": "wasi",
+                "message": "Please use node:wasi instead."
+              },
+              {
+                "name": "worker_threads",
+                "message": "Please use node:worker_threads instead."
+              },
+              {
+                "name": "zlib",
+                "message": "Please use node:zlib instead."
+              }
+            ]
+          }
         ]
       }
     },

--- a/packages/gateway-client/src/worker/p2p-client/bootstrap-list.ts
+++ b/packages/gateway-client/src/worker/p2p-client/bootstrap-list.ts
@@ -1,11 +1,14 @@
+import { WebSockets } from '@athena/shared/libp2p/@libp2p/websockets';
+import {
+    multiaddr,
+    Multiaddr,
+} from '@athena/shared/libp2p/@multiformats/multiaddr';
 import { Bootstrap } from '@libp2p/bootstrap';
 import { MultiaddrConnection } from '@libp2p/interface-connection';
 import type { Address } from '@libp2p/interface-peer-store';
 import { Upgrader } from '@libp2p/interface-transport';
 import { peerIdFromString } from '@libp2p/peer-id';
-import { WebSockets } from '@libp2p/websockets';
 import { P2P } from '@multiformats/mafmt';
-import { multiaddr, Multiaddr } from '@multiformats/multiaddr';
 import localforage from 'localforage';
 
 import type { P2pClient } from '.';

--- a/packages/gateway-client/src/worker/p2p-client/index.ts
+++ b/packages/gateway-client/src/worker/p2p-client/index.ts
@@ -1,14 +1,14 @@
-import { Noise } from '@chainsafe/libp2p-noise';
+import { Noise } from '@athena/shared/libp2p/@chainsafe/libp2p-noise';
+import { Mplex } from '@athena/shared/libp2p/@libp2p/mplex';
+import { WebSockets } from '@athena/shared/libp2p/@libp2p/websockets';
+import { Multiaddr as MultiaddrType } from '@athena/shared/libp2p/@multiformats/multiaddr';
+import { createLibp2p, Libp2p } from '@athena/shared/libp2p/libp2p';
 import { ConnectionEncrypter } from '@libp2p/interface-connection-encrypter';
 import { PeerId } from '@libp2p/interface-peer-id';
 import type { Address } from '@libp2p/interface-peer-store';
 import { KEEP_ALIVE } from '@libp2p/interface-peer-store/tags';
 import { StreamMuxerFactory } from '@libp2p/interface-stream-muxer';
-import { Mplex } from '@libp2p/mplex';
-import { WebSockets } from '@libp2p/websockets';
 import { all as filtersAll } from '@libp2p/websockets/filters';
-import { Multiaddr as MultiaddrType } from '@multiformats/multiaddr';
-import { createLibp2p, Libp2p } from 'libp2p';
 import { DefaultDialer } from 'libp2p/connection-manager/dialer';
 import { Libp2pNode } from 'libp2p/libp2p';
 

--- a/packages/gateway-client/src/worker/p2p-client/index.ts
+++ b/packages/gateway-client/src/worker/p2p-client/index.ts
@@ -29,6 +29,7 @@ export class P2pClient {
 
     private DIAL_TIMEOUT = 3000;
     private MAX_PARALLEL_DIALS = 20;
+    private MAX_DIALS_PER_PEER = 20;
 
     private streamFactory?: StreamFactory;
     private bootstrapList: BootstrapList;
@@ -40,7 +41,7 @@ export class P2pClient {
     private _connectionStatus: ServerPeerStatus = ServerPeerStatus.OFFLINE;
 
     public constructor() {
-        this.bootstrapList = new BootstrapList(this);
+        this.bootstrapList = new BootstrapList(this, this.MAX_DIALS_PER_PEER);
     }
 
     public get connectionStatus(): ServerPeerStatus {
@@ -133,7 +134,7 @@ export class P2pClient {
         this.log.debug('Re-adding server peer addresses');
         this.node.peerStore.addressBook.add(
             this.serverPeer,
-            this.bootstrapList.all().map(it => it.multiaddr)
+            this.bootstrapList.multiaddrList
         );
 
         // now, attempt to dial our server
@@ -247,7 +248,7 @@ export class P2pClient {
                 // explicitly disabled (removed in later version)
                 autoDial: false,
                 minConnections: 3,
-                maxDialsPerPeer: 20,
+                maxDialsPerPeer: this.MAX_DIALS_PER_PEER,
                 maxParallelDials: this.MAX_PARALLEL_DIALS,
                 addressSorter: (a: Address, b: Address) =>
                     this.bootstrapList.libp2pAddressSorter(a, b),

--- a/packages/networking-service/project.json
+++ b/packages/networking-service/project.json
@@ -34,8 +34,8 @@
         "assets": ["packages/networking-service/src/assets"],
         "fileReplacements": [
           {
-            "replace": "packages/shared/libp2p/src/index.ts",
-            "with": "dist/packages/shared/libp2p/main.js"
+            "replace": "packages/shared/libp2p/src",
+            "with": "dist/packages/shared/libp2p"
           }
         ]
       },

--- a/packages/networking-service/src/fetch-agent.ts
+++ b/packages/networking-service/src/fetch-agent.ts
@@ -1,11 +1,12 @@
-import yggdrasilDNS from './yggdrasil/dns';
-import http from 'http';
-import https from 'https';
-import dns from 'dns';
-import { LookupFunction } from 'net';
-import { Debug } from './logging';
-import type { RequestInit, Request, Response } from 'node-fetch';
+import type { Request, RequestInit, Response } from 'node-fetch';
+import dns from 'node:dns';
+import http from 'node:http';
+import https from 'node:https';
+import { LookupFunction } from 'node:net';
+
 import { environment } from './environment';
+import { Debug } from './logging';
+import yggdrasilDNS from './yggdrasil/dns';
 
 class FetchAgent {
     private readonly log = new Debug('fetch-agent');

--- a/packages/networking-service/src/libp2p/manager.ts
+++ b/packages/networking-service/src/libp2p/manager.ts
@@ -1,7 +1,8 @@
-import node from './node';
-import { writeFile } from 'fs/promises';
+import { writeFile } from 'node:fs/promises';
+
 import { environment } from '../environment';
 import { Debug } from '../logging';
+import node from './node';
 
 class Libp2pManager {
     private readonly log = new Debug('libp2p-manager');

--- a/packages/networking-service/src/libp2p/node.ts
+++ b/packages/networking-service/src/libp2p/node.ts
@@ -1,25 +1,25 @@
+import { Noise } from '@athena/shared/libp2p/@chainsafe/libp2p-noise';
+import { Mplex } from '@athena/shared/libp2p/@libp2p/mplex';
 import {
-    Mplex,
-    WebSockets,
-    Noise,
-    createLibp2p,
-    createFromProtobuf,
     createEd25519PeerId,
+    createFromProtobuf,
     exportToProtobuf,
-    Libp2p,
-    multiaddr,
-} from '@athena/shared/libp2p';
-import { readFile, writeFile } from 'fs/promises';
-import { environment } from '../environment';
+} from '@athena/shared/libp2p/@libp2p/peer-id-factory';
+import { WebSockets } from '@athena/shared/libp2p/@libp2p/websockets';
+import { multiaddr } from '@athena/shared/libp2p/@multiformats/multiaddr';
+import { createLibp2p, Libp2p } from '@athena/shared/libp2p/libp2p';
 import { ConnectionEncrypter } from '@libp2p/interface-connection-encrypter';
-import { StreamMuxerFactory } from '@libp2p/interface-stream-muxer';
 import {
     StreamHandler,
     StreamHandlerOptions,
 } from '@libp2p/interface-registrar';
-import { Deferred } from './streams/raw';
-import upnp from '../upnp';
+import { StreamMuxerFactory } from '@libp2p/interface-stream-muxer';
+import { readFile, writeFile } from 'node:fs/promises';
+
+import { environment } from '../environment';
 import { Debug } from '../logging';
+import upnp from '../upnp';
+import { Deferred } from './streams/raw';
 
 class Libp2pNode {
     private log = new Debug('libp2p-node');

--- a/packages/networking-service/src/libp2p/relays.ts
+++ b/packages/networking-service/src/libp2p/relays.ts
@@ -1,13 +1,15 @@
-import crawler from '../yggdrasil/crawler';
+import { multiaddr } from '@athena/shared/libp2p/@multiformats/multiaddr';
+import { EventEmitter } from 'node:stream';
+
+import { environment } from '../environment';
 import fetchAgent from '../fetch-agent';
+import { Debug } from '../logging';
 import upnp from '../upnp';
+import crawler from '../yggdrasil/crawler';
+import node from './node';
 import { HeartbeatStream, HeartbeatType } from './streams/heartbeat';
 import { Deferred } from './streams/raw';
-import node from './node';
-import { environment } from '../environment';
-import { EventEmitter } from 'stream';
-import { Debug } from '../logging';
-import { multiaddr } from '@athena/shared/libp2p';
+
 const waitFor = (ms: number) => new Promise(r => setTimeout(r, ms));
 
 class ActiveRelay {

--- a/packages/networking-service/src/libp2p/streams/lob-enc.ts
+++ b/packages/networking-service/src/libp2p/streams/lob-enc.ts
@@ -3,7 +3,7 @@
  *
  */
 
-import Stream from 'stream';
+import Stream from 'node:stream';
 
 export type Packet<J = Record<string, unknown>> = {
     head?: Buffer;

--- a/packages/networking-service/src/libp2p/streams/proxy.3.ts
+++ b/packages/networking-service/src/libp2p/streams/proxy.3.ts
@@ -1,11 +1,17 @@
-import { RawStream, Deferred } from './raw';
-import type { Request, Response, RequestInfo } from 'node-fetch';
-import fetchAgent from '../../fetch-agent';
 import { Stream } from '@libp2p/interface-connection';
-import { Readable } from 'stream';
-import { Debug } from '../../logging';
-import type { FetchError, RequestInit } from 'node-fetch';
+import type {
+    FetchError,
+    Request,
+    RequestInfo,
+    RequestInit,
+    Response,
+} from 'node-fetch';
 import { AbortSignal } from 'node-fetch/externals';
+import { Readable } from 'node:stream';
+
+import fetchAgent from '../../fetch-agent';
+import { Debug } from '../../logging';
+import { Deferred, RawStream } from './raw';
 
 enum ChunkType {
     HEAD = 0x00,

--- a/packages/networking-service/src/libp2p/streams/raw.ts
+++ b/packages/networking-service/src/libp2p/streams/raw.ts
@@ -1,5 +1,6 @@
 import { Stream } from '@libp2p/interface-connection';
-import { EventEmitter } from 'stream';
+import { EventEmitter } from 'node:stream';
+
 import { Debug } from '../../logging';
 
 export class Deferred<T> {

--- a/packages/networking-service/src/upnp.ts
+++ b/packages/networking-service/src/upnp.ts
@@ -1,6 +1,7 @@
+import { internalIpV4 } from '@athena/shared/libp2p/internal-ip';
 import type { Mapping } from 'node-portmapping';
+
 import { environment } from './environment';
-import { internalIpV4 } from '@athena/shared/libp2p';
 import { Debug } from './logging';
 
 let natMapping: typeof import('node-portmapping') | null = null;

--- a/packages/networking-service/src/yggdrasil/config.ts
+++ b/packages/networking-service/src/yggdrasil/config.ts
@@ -1,5 +1,6 @@
+import { readFileSync, writeFile } from 'node:fs';
+
 import { environment } from '../environment';
-import { readFileSync, writeFile } from 'fs';
 import { Debug } from '../logging';
 import upnp from '../upnp';
 

--- a/packages/networking-service/src/yggdrasil/crawler.ts
+++ b/packages/networking-service/src/yggdrasil/crawler.ts
@@ -1,5 +1,5 @@
 import { ScalableBloomFilter } from 'bloom-filters';
-import { EventEmitter } from 'stream';
+import { EventEmitter } from 'node:stream';
 
 import { environment } from '../environment';
 import { Debug } from '../logging';

--- a/packages/networking-service/src/yggdrasil/dns.ts
+++ b/packages/networking-service/src/yggdrasil/dns.ts
@@ -1,14 +1,15 @@
-import rpc from './rpc';
 import {
-    readFileSync,
-    readFile,
-    writeFile,
-    utimesSync,
-    openSync,
     closeSync,
-} from 'fs';
+    openSync,
+    readFile,
+    readFileSync,
+    utimesSync,
+    writeFile,
+} from 'node:fs';
+
 import { environment } from '../environment';
 import { Debug } from '../logging';
+import rpc from './rpc';
 
 const HOST_HEADER = `
 127.0.0.1	localhost.localdomain		localhost

--- a/packages/networking-service/src/yggdrasil/manager.ts
+++ b/packages/networking-service/src/yggdrasil/manager.ts
@@ -1,11 +1,12 @@
+import { writeFile } from 'node:fs/promises';
+
+import { environment } from '../environment';
+import fetchAgent from '../fetch-agent';
+import { Debug } from '../logging';
+import upnp from '../upnp';
+import config from './config';
 import crawler from './crawler';
 import { NodeInfo } from './rpc';
-import config from './config';
-import fetchAgent from '../fetch-agent';
-import { environment } from '../environment';
-import upnp from '../upnp';
-import { writeFile } from 'fs/promises';
-import { Debug } from '../logging';
 
 class YggdrasilManager {
     private readonly log = new Debug('yggdrasil-manager');

--- a/packages/shared/libp2p/.eslintrc.json
+++ b/packages/shared/libp2p/.eslintrc.json
@@ -4,7 +4,9 @@
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
-      "rules": {}
+      "rules": {
+        "no-restricted-imports": "off"
+      }
     },
     {
       "files": ["*.ts", "*.tsx"],

--- a/packages/shared/libp2p/project.json
+++ b/packages/shared/libp2p/project.json
@@ -13,6 +13,36 @@
         "tsConfig": "packages/shared/libp2p/tsconfig.json",
         "verbose": true,
         "externalDependencies": ["bufferutil", "utf-8-validate"],
+        "additionalEntryPoints": [
+          {
+            "entryName": "@chainsafe/libp2p-noise",
+            "entryPath": "packages/shared/libp2p/src/@chainsafe/libp2p-noise.ts"
+          },
+          {
+            "entryName": "@libp2p/mplex",
+            "entryPath": "packages/shared/libp2p/src/@libp2p/mplex.ts"
+          },
+          {
+            "entryName": "@libp2p/peer-id-factory",
+            "entryPath": "packages/shared/libp2p/src/@libp2p/peer-id-factory.ts"
+          },
+          {
+            "entryName": "@libp2p/websockets",
+            "entryPath": "packages/shared/libp2p/src/@libp2p/websockets.ts"
+          },
+          {
+            "entryName": "@multiformats/multiaddr",
+            "entryPath": "packages/shared/libp2p/src/@multiformats/multiaddr.ts"
+          },
+          {
+            "entryName": "internal-ip",
+            "entryPath": "packages/shared/libp2p/src/internal-ip.ts"
+          },
+          {
+            "entryName": "libp2p",
+            "entryPath": "packages/shared/libp2p/src/libp2p.ts"
+          }
+        ],
         "webpackConfig": "packages/shared/libp2p/webpack.config.js"
       }
     },

--- a/packages/shared/libp2p/src/@chainsafe/libp2p-noise.ts
+++ b/packages/shared/libp2p/src/@chainsafe/libp2p-noise.ts
@@ -1,0 +1,1 @@
+export * from '@chainsafe/libp2p-noise';

--- a/packages/shared/libp2p/src/@libp2p/mplex.ts
+++ b/packages/shared/libp2p/src/@libp2p/mplex.ts
@@ -1,0 +1,1 @@
+export * from '@libp2p/mplex';

--- a/packages/shared/libp2p/src/@libp2p/peer-id-factory.ts
+++ b/packages/shared/libp2p/src/@libp2p/peer-id-factory.ts
@@ -1,0 +1,1 @@
+export * from '@libp2p/peer-id-factory';

--- a/packages/shared/libp2p/src/@libp2p/websockets.ts
+++ b/packages/shared/libp2p/src/@libp2p/websockets.ts
@@ -1,0 +1,1 @@
+export * from '@libp2p/websockets';

--- a/packages/shared/libp2p/src/@multiformats/multiaddr.ts
+++ b/packages/shared/libp2p/src/@multiformats/multiaddr.ts
@@ -1,0 +1,1 @@
+export * from '@multiformats/multiaddr';

--- a/packages/shared/libp2p/src/index.ts
+++ b/packages/shared/libp2p/src/index.ts
@@ -1,7 +1,0 @@
-export * from 'libp2p';
-export * from '@libp2p/peer-id-factory';
-export * from '@libp2p/mplex';
-export * from '@libp2p/websockets';
-export * from '@chainsafe/libp2p-noise';
-export * from 'internal-ip';
-export * from '@multiformats/multiaddr';

--- a/packages/shared/libp2p/src/internal-ip.ts
+++ b/packages/shared/libp2p/src/internal-ip.ts
@@ -1,0 +1,1 @@
+export * from 'internal-ip';

--- a/packages/shared/libp2p/src/libp2p.ts
+++ b/packages/shared/libp2p/src/libp2p.ts
@@ -1,0 +1,1 @@
+export * from 'libp2p';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,7 +16,7 @@
     "baseUrl": ".",
     "paths": {
       "@athena/shared/api": ["packages/shared/api/src/index.ts"],
-      "@athena/shared/libp2p": ["packages/shared/libp2p/src/index.ts"],
+      "@athena/shared/libp2p/*": ["packages/shared/libp2p/src/*"],
       "@athena/shared/service-worker": [
         "packages/shared/service-worker/src/index.ts"
       ]


### PR DESCRIPTION
Resolves a few issues I had with the way the `shared/libp2p` was currently setup:
- No way to tell which module an import came from
- Risk of conflicts between different modules
- No way to know whether to import directly from module or from shared library
- No way to know which modules needed to be imported from shared library

Now:
- The names of all modules are preserved when importing
- Importing should always be done from shared library (even when not necessary)
- Eslint rule will tell us which modules need to be imported from shared library