### PR TITLE
SAM-94 prune invalid p2p addresses

### DIFF
--- a/packages/gateway-client/src/worker/p2p-client/bootstrap/bootstrap-address.ts
+++ b/packages/gateway-client/src/worker/p2p-client/bootstrap/bootstrap-address.ts
@@ -1,0 +1,74 @@
+import {
+    multiaddr,
+    Multiaddr,
+} from '@athena/shared/libp2p/@multiformats/multiaddr';
+import { P2P } from '@multiformats/mafmt';
+
+export class BootstrapAddress {
+    public multiaddr: Multiaddr;
+    public lastSeen = 0;
+    public latency = Infinity;
+    public isRelay = false;
+    public isDNS = false;
+    public address: string;
+
+    private _serverId: string;
+
+    public constructor(address: string) {
+        if (!P2P.matches(address)) {
+            throw new Error('Invalid multiaddr');
+        }
+
+        this.multiaddr = multiaddr(address);
+        const serverId = this.multiaddr.getPeerId();
+        if (!serverId) {
+            throw new Error(
+                `Address ${address} contains invalid or missing peer id.`
+            );
+        }
+
+        this.address = this.multiaddr.toString();
+        this._serverId = serverId;
+        this.isRelay = this.address.includes('/p2p-circuit/');
+        this.isDNS = this.address.includes('/dns4/');
+    }
+
+    static fromJson(json: Record<string, unknown>): BootstrapAddress {
+        const addr = new BootstrapAddress(json.address as string);
+        addr.lastSeen = json.lastSeen as number;
+        addr.latency = json.latency as number;
+        return addr;
+    }
+
+    toJson(): Record<string, unknown> {
+        return {
+            address: this.address ?? '',
+            lastSeen: this.lastSeen ?? Date.now(),
+            latency: this.latency ?? Infinity,
+        };
+    }
+
+    toString(): string {
+        return this.address;
+    }
+
+    get serverId(): string {
+        return this._serverId;
+    }
+
+    set serverId(id: string) {
+        // update multiaddr
+        const newMultiaddr = multiaddr(
+            this.multiaddr.toString().replace(this._serverId, id)
+        );
+        const newServerId = newMultiaddr.getPeerId();
+        if (!newServerId) {
+            throw new Error(
+                `Error setting serverId: ${id} (was parsed to: ${newServerId}).`
+            );
+        }
+        this.address = newMultiaddr.toString();
+        this.multiaddr = newMultiaddr;
+        this._serverId = newServerId;
+    }
+}

--- a/packages/gateway-client/src/worker/p2p-client/bootstrap/bootstrap-list.ts
+++ b/packages/gateway-client/src/worker/p2p-client/bootstrap/bootstrap-list.ts
@@ -2,10 +2,10 @@ import { Bootstrap } from '@libp2p/bootstrap';
 import type { Address } from '@libp2p/interface-peer-store';
 import { peerIdFromString } from '@libp2p/peer-id';
 import localforage from 'localforage';
-import { ServerPeerStatus } from 'packages/gateway-client/src/worker-messaging';
 
 import type { P2pClient } from '..';
 import environment from '../../../environment';
+import { ServerPeerStatus } from '../../../worker-messaging';
 import { logger } from '../../logging';
 import { nativeFetch } from '../../p2p-fetch';
 import status from '../../status';

--- a/packages/gateway-client/src/worker/p2p-client/bootstrap/index.ts
+++ b/packages/gateway-client/src/worker/p2p-client/bootstrap/index.ts
@@ -1,0 +1,1 @@
+export { BootstrapList } from './bootstrap-list';

--- a/packages/gateway-client/src/worker/p2p-client/bootstrap/stats-transports.ts
+++ b/packages/gateway-client/src/worker/p2p-client/bootstrap/stats-transports.ts
@@ -1,0 +1,63 @@
+import { WebSockets } from '@athena/shared/libp2p/@libp2p/websockets';
+import { MultiaddrConnection } from '@libp2p/interface-connection';
+import { Upgrader } from '@libp2p/interface-transport';
+
+import { logger } from '../../logging';
+import { BootstrapAddress } from './bootstrap-address';
+import { BootstrapList } from './bootstrap-list';
+
+const log = logger.getLogger('worker/p2p/bootstrap/stats');
+
+export type StatsTransport = (
+    list: BootstrapList,
+    address: BootstrapAddress,
+    signal: AbortSignal
+) => Promise<number>;
+
+export const websocketStats: StatsTransport = async (list, address, signal) => {
+    // send websocket request, track time
+    const start = Date.now();
+    let socket;
+    let latency = Infinity;
+    try {
+        socket = await new WebSockets().dial(
+            address.isRelay
+                ? address.multiaddr.decapsulate('p2p-circuit')
+                : address.multiaddr,
+            {
+                signal,
+                upgrader: {
+                    upgradeOutbound: async (socket: MultiaddrConnection) =>
+                        socket,
+                } as unknown as Upgrader,
+            }
+        );
+        latency = Date.now() - start;
+    } catch (e) {
+        log.debug(`Failed to connect to ${address}: `, e);
+    }
+    // close the socket
+    try {
+        if (socket) {
+            await socket.close();
+        }
+    } catch (e) {
+        log.warn(`Failed to close socket to ${address}: `, e);
+    }
+    return latency;
+};
+
+export const pingStats: StatsTransport = async (list, address, signal) => {
+    // we need a libp2p node for this
+    if (!list.client.node) {
+        throw new Error('No client connection established!');
+    }
+    try {
+        return await list.client.ping(address.multiaddr, {
+            signal,
+        });
+    } catch (e) {
+        log.debug(`Failed to ping ${address}: `, e);
+    }
+    return Infinity;
+};

--- a/packages/gateway-client/src/worker/p2p-client/index.ts
+++ b/packages/gateway-client/src/worker/p2p-client/index.ts
@@ -19,7 +19,7 @@ import { ClientMessageType, ServerPeerStatus } from '../../worker-messaging';
 import { logger } from '../logging';
 import messenger from '../messenger';
 import status from '../status';
-import { BootstrapList } from './bootstrap-list';
+import { BootstrapList } from './bootstrap';
 import { initLibp2pLogging } from './libp2p-logging';
 import { PingService } from './ping-service';
 import { StreamFactory } from './stream-factory';

--- a/packages/gateway-client/src/worker/p2p-client/index.ts
+++ b/packages/gateway-client/src/worker/p2p-client/index.ts
@@ -1,7 +1,7 @@
 import { Noise } from '@athena/shared/libp2p/@chainsafe/libp2p-noise';
 import { Mplex } from '@athena/shared/libp2p/@libp2p/mplex';
 import { WebSockets } from '@athena/shared/libp2p/@libp2p/websockets';
-import { Multiaddr as MultiaddrType } from '@athena/shared/libp2p/@multiformats/multiaddr';
+import { Multiaddr } from '@athena/shared/libp2p/@multiformats/multiaddr';
 import { createLibp2p, Libp2p } from '@athena/shared/libp2p/libp2p';
 import { Connection } from '@libp2p/interface-connection';
 import { ConnectionEncrypter } from '@libp2p/interface-connection-encrypter';
@@ -9,6 +9,7 @@ import { PeerId } from '@libp2p/interface-peer-id';
 import type { Address } from '@libp2p/interface-peer-store';
 import { KEEP_ALIVE } from '@libp2p/interface-peer-store/tags';
 import { StreamMuxerFactory } from '@libp2p/interface-stream-muxer';
+import { AbortOptions } from '@libp2p/interfaces';
 import { all as filtersAll } from '@libp2p/websockets/filters';
 import { DefaultConnectionManager } from 'libp2p/connection-manager';
 import { DefaultDialer } from 'libp2p/connection-manager/dialer';
@@ -20,6 +21,7 @@ import messenger from '../messenger';
 import status from '../status';
 import { BootstrapList } from './bootstrap-list';
 import { initLibp2pLogging } from './libp2p-logging';
+import { PingService } from './ping-service';
 import { StreamFactory } from './stream-factory';
 import { HeartbeatStream } from './streams';
 
@@ -53,6 +55,7 @@ export class P2pClient {
 
     private streamFactory?: StreamFactory;
     private bootstrapList: BootstrapList;
+    private pingService: PingService;
     private eventTarget = new EventTarget();
 
     private serverPeer?: PeerId;
@@ -62,6 +65,7 @@ export class P2pClient {
 
     public constructor() {
         this.bootstrapList = new BootstrapList(this, this.MAX_DIALS_PER_PEER);
+        this.pingService = new PingService(this);
     }
 
     public get connectionStatus(): ServerPeerStatus {
@@ -73,7 +77,7 @@ export class P2pClient {
         status.serverPeer = connectionStatus;
     }
 
-    public async addServerPeerAddress(multiaddr: MultiaddrType) {
+    public async addServerPeerAddress(multiaddr: Multiaddr) {
         if (!this.serverPeer) {
             throw new Error('No server peer discovered.');
         }
@@ -249,7 +253,7 @@ export class P2pClient {
             // timeout configurable via `init.ping.timeout`,
             // default is 10 seconds
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            await this.node!.ping(this.serverPeer!);
+            await this.ping(this.serverPeer!);
             // if our ping was successful, then our connection is still good
             this.log.trace('Ping successful!');
         } catch (e) {
@@ -443,6 +447,13 @@ export class P2pClient {
                 this.connectionStatus = ServerPeerStatus.OFFLINE;
             }
         });
+    }
+
+    public async ping(
+        peer: Multiaddr | PeerId,
+        options?: AbortOptions
+    ): Promise<number> {
+        return this.pingService.ping(peer, options);
     }
 
     private async handleWebsocketMessages() {

--- a/packages/gateway-client/src/worker/p2p-client/ping-service.ts
+++ b/packages/gateway-client/src/worker/p2p-client/ping-service.ts
@@ -1,0 +1,64 @@
+/*
+ * This service works around the following bug in libp2p:
+ * https://github.com/libp2p/js-libp2p/issues/1530
+ *
+ * In order to prevent calling ping() concurrently,
+ * we asynchronously queue concurrent calls to ping().
+ *
+ */
+
+import { Multiaddr } from '@athena/shared/libp2p/@multiformats/multiaddr';
+import { PeerId } from '@libp2p/interface-peer-id';
+import { AbortOptions } from '@libp2p/interfaces';
+import { P2pClient } from '.';
+
+import { logger } from '../logging';
+
+export class PingService {
+    private readonly log = logger.getLogger('worker/p2p/ping');
+
+    private readonly queue: Array<() => Promise<void>> = [];
+
+    private isRunning = false;
+
+    constructor(private readonly client: P2pClient) {}
+
+    private readonly run = async () => {
+        if (this.isRunning) {
+            return;
+        }
+        this.isRunning = true;
+        while (this.queue.length > 0) {
+            const next = this.queue.shift();
+            if (next) {
+                await next();
+            }
+        }
+        this.isRunning = false;
+    };
+
+    private enqueue = <T>(fn: () => Promise<T>) => {
+        return new Promise<T>((resolve, reject) => {
+            this.queue.push(async () => {
+                try {
+                    resolve(await fn());
+                } catch (e) {
+                    reject(e);
+                }
+            });
+            this.run();
+        });
+    };
+
+    async ping(
+        peer: Multiaddr | PeerId,
+        options?: AbortOptions
+    ): Promise<number> {
+        return this.enqueue(async () => {
+            if (!this.client.node) {
+                throw new Error('Node not started!');
+            }
+            return this.client.node.ping(peer, options);
+        });
+    }
+}


### PR DESCRIPTION
- Works around https://github.com/libp2p/js-libp2p/issues/1530 by introducing new ping service
- Using `ping()` instead of websockets to collect stats on bootstrap addresses (if a connection exists)
- Splits bootstrap-list into multiple files under `bootstrap/`