### PR TITLE
Wait for controllerchange event to execute onSuccess() of newly installed worker in registration.ts

### DIFF
--- a/packages/shared/service-worker/src/lib/registration.ts
+++ b/packages/shared/service-worker/src/lib/registration.ts
@@ -92,6 +92,7 @@ function registerValidSW(swUrl: string, config?: Config) {
             }
             registration.onupdatefound = () => {
                 const installingWorker = registration.installing;
+                let newWorker = false;
                 if (installingWorker == null) {
                     return;
                 }
@@ -107,22 +108,25 @@ function registerValidSW(swUrl: string, config?: Config) {
                             );
 
                             // Execute callback
-                            if (config && config.onUpdate) {
-                                config.onUpdate(registration);
-                            }
+                            config?.onUpdate?.(registration);
                         } else {
                             // At this point, everything has been precached.
                             // It's the perfect time to display a
                             // "Content is cached for offline use." message.
                             console.log('Content is cached for offline use.');
-
-                            // Execute callback
-                            if (config && config.onSuccess) {
-                                config.onSuccess(registration);
-                            }
+                            newWorker = true;
                         }
                     }
                 };
+                navigator.serviceWorker.addEventListener(
+                    'controllerchange',
+                    () => {
+                        if (newWorker) {
+                            // Execute callback
+                            config?.onSuccess?.(registration);
+                        }
+                    }
+                );
             };
         })
         .catch(error => {


### PR DESCRIPTION
The controller isn't resolved until _after_ the service worker becomes activated (as opposed to at the same time). Listen for a `controllerchange` instead of a `statechange` event to fire registration success callback.

https://github.com/w3c/ServiceWorker/issues/799